### PR TITLE
Replace 'google.com' with 'google_com' in bucket names.

### DIFF
--- a/cli_tools/common/utils/storage/scratch_bucket_creator.go
+++ b/cli_tools/common/utils/storage/scratch_bucket_creator.go
@@ -152,7 +152,7 @@ func (c *ScratchBucketCreator) getBucketAttrsIfInProject(project string, bucketN
 }
 
 func (c *ScratchBucketCreator) formatScratchBucketName(project string, location string) string {
-	bucket := strings.Replace(project, ":", "-", -1) + "-daisy-bkt"
+	bucket := strings.Replace(strings.Replace(project, "google.com", "google_com", -1), ":", "-", -1) + "-daisy-bkt"
 	if location != "" {
 		bucket = bucket + "-" + location
 	}


### PR DESCRIPTION
Cloud Bucket policy prevents the use of 'google.com' in the name. Replace it with the friendlier 'google_com' so we don't also chop off the front of the scratch bucket name.